### PR TITLE
Add support for reading wav files with the WAVE_FORMAT_IEEE_FLOAT format.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ use hound;
 let spec = hound::WavSpec {
     channels: 1,
     sample_rate: 44100,
-    bits_per_sample: 16
+    bits_per_sample: 16,
+    sample_format: hound::SampleFormat::Int,
 };
 let mut writer = hound::WavWriter::create("sine.wav", spec).unwrap();
 for t in (0 .. 44100).map(|x| x as f32 / 44100.0) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,12 @@ pub use write::WavWriter;
 
 /// A type that can be used to represent audio samples.
 ///
-/// Via this trait, decoding can be generic over `i8`, `i16` and `i32`. All bit
-/// depths up to 32 bits per sample can be decoded into `i32`, but it takes up
-/// more memory. If you know beforehand that you will be reading a file with
-/// 16 bits per sample, then decoding into an `i16` will be sufficient.
+/// Via this trait, decoding can be generic over `i8`, `i16`, `i32` and `f32`.
+///
+/// All integer formats with bit depths up to 32 bits per sample can be decoded
+/// into `i32`, but it takes up more memory. If you know beforehand that you
+/// will be reading a file with 16 bits per sample, then decoding into an `i16`
+/// will be sufficient.
 pub trait Sample: Sized {
     /// Writes the audio sample to the WAVE data chunk.
     fn write<W: io::Write>(self, writer: &mut W, bits: u16) -> Result<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,8 @@
 //! let spec = hound::WavSpec {
 //!     channels: 1,
 //!     sample_rate: 44100,
-//!     bits_per_sample: 16
+//!     bits_per_sample: 16,
+//!     sample_format: hound::SampleFormat::Int,
 //! };
 //! let mut writer = hound::WavWriter::create("sine.wav", spec).unwrap();
 //! for t in (0 .. 44100).map(|x| x as f32 / 44100.0) {
@@ -374,7 +375,8 @@ fn write_read_i16_is_lossless() {
     let write_spec = WavSpec {
         channels: 2,
         sample_rate: 44100,
-        bits_per_sample: 16
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
     };
 
     {
@@ -401,7 +403,8 @@ fn write_read_i8_is_lossless() {
     let write_spec = WavSpec {
         channels: 16,
         sample_rate: 48000,
-        bits_per_sample: 8
+        bits_per_sample: 8,
+        sample_format: SampleFormat::Int,
     };
 
     // Write `i8` samples.
@@ -431,7 +434,8 @@ fn write_read_i24_is_lossless() {
     let write_spec = WavSpec {
         channels: 16,
         sample_rate: 96000,
-        bits_per_sample: 24
+        bits_per_sample: 24,
+        sample_format: SampleFormat::Int,
     };
 
     // Write `i32` samples, but with at most 24 bits per sample.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,9 @@ impl Sample for f32 {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SampleFormat {
     /// Wave files with the `WAVE_FORMAT_IEEE_FLOAT` format tag store samples as floating point
-    /// values with a full scale of 1.0.
+    /// values.
+    ///
+    /// Values are normally in the range [-1.0, 1.0].
     Float,
     /// Wave files with the `WAVE_FORMAT_PCM` format tag store samples as integer values.
     Int,

--- a/src/read.rs
+++ b/src/read.rs
@@ -445,8 +445,10 @@ impl<R> WavReader<R> where R: io::Read {
         let mut subformat = [0u8; 16];
         try!(reader.read_into(&mut subformat));
 
-        // Several GUIDS are defined. At the moment, only KSDATAFORMAT_SUBTYPE_PCM
-        // is supported (PCM audio with integer samples).
+        // Several GUIDS are defined. At the moment, only the following are supported:
+        //
+        // * KSDATAFORMAT_SUBTYPE_PCM (PCM audio with integer samples).
+        // * KSDATAFORMAT_SUBTYPE_IEEE_FLOAT (PCM audio with floating point samples).
         let sample_format = match subformat {
             super::KSDATAFORMAT_SUBTYPE_PCM => SampleFormat::Int,
             super::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT => SampleFormat::Float,

--- a/src/read.rs
+++ b/src/read.rs
@@ -398,6 +398,16 @@ impl<R> WavReader<R> where R: io::Read {
             }
         }
 
+        // For WAVE_FORMAT_IEEE_FLOAT, the bits_per_sample field should be
+        // set to `32` according to
+        // https://msdn.microsoft.com/en-us/library/windows/hardware/ff538799(v=vs.85).aspx.
+        //
+        // Note that some applications support 64 bits per sample. This is
+        // not yet supported by hound.
+        if spec.bits_per_sample != 32 {
+            return Err(Error::FormatError("bits per sample is not 32"));
+        }
+
         let spec_ex = WavSpecEx {
             spec: WavSpec {
                 sample_format: SampleFormat::Float,

--- a/src/read.rs
+++ b/src/read.rs
@@ -636,6 +636,7 @@ where R: io::Read,
     if reader.samples_read < reader.num_samples {
         reader.samples_read += 1;
         let sample = Sample::read(&mut reader.reader,
+                                  reader.spec.sample_format,
                                   reader.bytes_per_sample,
                                   reader.spec.bits_per_sample);
         Some(sample.map_err(Error::from))

--- a/src/read.rs
+++ b/src/read.rs
@@ -447,11 +447,6 @@ impl<R> WavReader<R> where R: io::Read {
 
         // Several GUIDS are defined. At the moment, only KSDATAFORMAT_SUBTYPE_PCM
         // is supported (PCM audio with integer samples).
-        if subformat != super::KSDATAFORMAT_SUBTYPE_PCM
-        && subformat != super::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT {
-            return Err(Error::Unsupported);
-        }
-
         let sample_format = match subformat {
             super::KSDATAFORMAT_SUBTYPE_PCM => SampleFormat::Int,
             super::KSDATAFORMAT_SUBTYPE_IEEE_FLOAT => SampleFormat::Float,

--- a/src/read.rs
+++ b/src/read.rs
@@ -723,6 +723,7 @@ fn read_wav_skips_unknown_chunks() {
         assert_eq!(wav_reader.spec().channels, 1);
         assert_eq!(wav_reader.spec().sample_rate, 44100);
         assert_eq!(wav_reader.spec().bits_per_sample, 16);
+        assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
         let sample = wav_reader.samples::<i16>().next().unwrap().unwrap();
         assert_eq!(sample, 2);
@@ -801,6 +802,7 @@ fn read_wav_wave_format_ex_pcm() {
     assert_eq!(wav_reader.spec().channels, 1);
     assert_eq!(wav_reader.spec().sample_rate, 44100);
     assert_eq!(wav_reader.spec().bits_per_sample, 16);
+    assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
     let samples: Vec<i16> = wav_reader.samples()
                                       .map(|r| r.unwrap())
@@ -818,6 +820,7 @@ fn read_wav_stereo() {
     assert_eq!(wav_reader.spec().channels, 2);
     assert_eq!(wav_reader.spec().sample_rate, 44100);
     assert_eq!(wav_reader.spec().bits_per_sample, 16);
+    assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
     let samples: Vec<i16> = wav_reader.samples()
                                       .map(|r| r.unwrap())
@@ -834,6 +837,7 @@ fn read_wav_8bit() {
                                    .unwrap();
 
     assert_eq!(wav_reader.spec().bits_per_sample, 8);
+    assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
     let samples: Vec<i16> = wav_reader.samples()
                                       .map(|r| r.unwrap())
@@ -852,6 +856,7 @@ fn read_wav_wave_format_extensible_pcm_24bit() {
     assert_eq!(wav_reader.spec().channels, 1);
     assert_eq!(wav_reader.spec().sample_rate, 192_000);
     assert_eq!(wav_reader.spec().bits_per_sample, 24);
+    assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
     let samples: Vec<i32> = wav_reader.samples()
                                       .map(|r| r.unwrap())
@@ -867,6 +872,7 @@ fn read_wav_32bit() {
                                    .unwrap();
 
     assert_eq!(wav_reader.spec().bits_per_sample, 32);
+    assert_eq!(wav_reader.spec().sample_format, SampleFormat::Int);
 
     let samples: Vec<i32> = wav_reader.samples()
                                       .map(|r| r.unwrap())

--- a/src/write.rs
+++ b/src/write.rs
@@ -309,12 +309,15 @@ impl WavWriter<io::BufWriter<fs::File>> {
 
 #[test]
 fn short_write_should_signal_error() {
+    use SampleFormat;
+
     let mut buffer = io::Cursor::new(Vec::new());
 
     let write_spec = WavSpec {
         channels: 17,
         sample_rate: 48000,
-        bits_per_sample: 8
+        bits_per_sample: 8,
+        sample_format: SampleFormat::Int,
     };
 
     // Deliberately write one sample less than 17 * 5.
@@ -332,12 +335,15 @@ fn short_write_should_signal_error() {
 
 #[test]
 fn wide_write_should_signal_error() {
+    use SampleFormat;
+
     let mut buffer = io::Cursor::new(Vec::new());
 
     let spec8 = WavSpec {
         channels: 1,
         sample_rate: 44100,
-        bits_per_sample: 8
+        bits_per_sample: 8,
+        sample_format: SampleFormat::Int,
     };
     {
         let mut writer = WavWriter::new(&mut buffer, spec8);

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,6 +12,7 @@
 
 use std::fs;
 use std::io;
+use std::mem;
 use std::io::Write;
 use std::path;
 use super::{Error, Result, Sample, WavSpec};
@@ -44,6 +45,9 @@ pub trait WriteExt: io::Write {
 
     /// Writes an unsigned 32-bit integer in little endian format.
     fn write_le_u32(&mut self, x: u32) -> io::Result<()>;
+
+    /// Writes an IEEE float in little endian format.
+    fn write_le_f32(&mut self, x: f32) -> io::Result<()>;
 }
 
 impl<W> WriteExt for W where W: io::Write {
@@ -86,6 +90,11 @@ impl<W> WriteExt for W where W: io::Write {
         buf[2] = ((x >> 16) & 0xff) as u8;
         buf[3] = ((x >> 24) & 0xff) as u8;
         self.write_all(&buf)
+    }
+
+    fn write_le_f32(&mut self, x: f32) -> io::Result<()> {
+        let u = unsafe { mem::transmute(x) };
+        self.write_le_u32(u)
     }
 }
 


### PR DESCRIPTION
I'm using hound to load samples for a sampler instrument I'm working on. I noticed that about a third of my sample library was failing to load as many wav files were formatted with `IEEE_FLOAT` data, so I thought I'd have a go at implementing support.

This only adds working support for reading the float format so far. It does add a `WriterExt::write_le_f32` in order to complete `Sample` implementation for `f32`, however functionality for writing IEEE_FLOAT waves is not yet implemented.

This also adds a `SampleFormat` type and a `sample_format` field to the `WavSpec` in order to help the user distinguish between whether the sample is formatted as float or integer data.

I'll try to add a test .wav file with a couple tests over the next couple of days if I can find the time.

@ruuda it would be great if you could have a look over this and let me know your thoughts, whether or not your interested, if you'd like me to change the anything, etc. I really appreciate your work on hound - super nice and simple API and the src has been very easy to read through :)