### PR TITLE
Fix build after adding RMS example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,10 @@ matrix:
   include:
     - os: osx
       rust: stable
+
+# The RMS example relies on f64 implementing From<i32> and From<f32>, which is
+# not the case in older versions of Rust. (It was added in Rust 1.6.0.) Because
+# this is only an example, and the library still compiles, I think it is fine to
+# just skip this single example in this case.
+before_script:
+  - if [[ "$TRAVIS_RUST_VERSION" == "1.4.0" ]]; then rm examples/rms.rs; fi


### PR DESCRIPTION
1147c79c2fd8ad7e6ee9b13656f653c41380b4a5 broke the build. The RMS example requires at least Rust 1.6.0, so don’t run it on 1.4.0. Fortunately it is an example and not in the core library, so this does not have to be a breaking change.

The Travis build of this pull request confirms that the fix works.