### PR TITLE
basic support for arbitrary chunks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,3 @@
-[root]
-name = "hound"
-version = "3.4.0"
-dependencies = [
- "cpal 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "alsa-sys"
 version = "0.1.1"
@@ -48,6 +41,13 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hound"
+version = "3.4.0"
+dependencies = [
+ "cpal 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,3 +1,10 @@
+[root]
+name = "hound"
+version = "3.4.0"
+dependencies = [
+ "cpal 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [[package]]
 name = "alsa-sys"
 version = "0.1.1"
@@ -41,13 +48,6 @@ dependencies = [
  "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "hound"
-version = "3.4.0"
-dependencies = [
- "cpal 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,7 +792,7 @@ fn append_works_on_files() {
 }
 
 #[cfg(test)]
-macro_rules! gard {
+macro_rules! guard {
     ($pat:pat = $expr:expr => $block:block) => {
         if let $pat = $expr {
             $block
@@ -809,19 +809,19 @@ fn read_non_standard_chunks() {
     use std::io::Read;
     let mut file = fs::File::open("testsamples/nonstandard-01.wav").unwrap();
     let mut reader = read::ChunksReader::new(&mut file).unwrap();
-    gard!(Some(read::Chunk::Unknown(kind, _reader)) = reader.next().unwrap() => {
+    guard!(Some(read::Chunk::Unknown(kind, _reader)) = reader.next().unwrap() => {
         assert_eq!(kind, *b"JUNK");
     });
-    gard!(Some(read::Chunk::Unknown(kind, mut reader)) = reader.next().unwrap() => {
+    guard!(Some(read::Chunk::Unknown(kind, mut reader)) = reader.next().unwrap() => {
         assert_eq!(kind, *b"bext");
         let mut v = vec!();
         reader.read_to_end(&mut v).unwrap();
         assert!((0..v.len()).any(|offset| &v[offset..offset+9] == b"Pro Tools"));
     });
-    gard!(Some(read::Chunk::Fmt(_)) = reader.next().unwrap() => { () });
-    gard!(Some(read::Chunk::Unknown(kind, _len)) = reader.next().unwrap() => {
+    guard!(Some(read::Chunk::Fmt(_)) = reader.next().unwrap() => { () });
+    guard!(Some(read::Chunk::Unknown(kind, _len)) = reader.next().unwrap() => {
         assert_eq!(kind, *b"minf");
     });
-    gard!(Some(read::Chunk::Data) = reader.next().unwrap() => { () });
+    guard!(Some(read::Chunk::Data) = reader.next().unwrap() => { () });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,8 @@ pub enum Error {
     IoError(io::Error),
     /// Ill-formed WAVE data was encountered.
     FormatError(&'static str),
+    /// An inconsistency in parsing chunks has been detected.
+    InvalidState(&'static str),
     /// The sample has more bits than the destination type.
     ///
     /// When iterating using the `samples` iterator, this means that the
@@ -358,6 +360,10 @@ impl fmt::Display for Error {
                 try!(formatter.write_str("Ill-formed WAVE file: "));
                 formatter.write_str(reason)
             }
+            Error::InvalidState(reason) => {
+                try!(formatter.write_str("Invalid WAVE parser state"));
+                formatter.write_str(reason)
+            }
             Error::TooWide => {
                 formatter.write_str("The sample has more bits than the destination type.")
             }
@@ -380,6 +386,7 @@ impl error::Error for Error {
         match *self {
             Error::IoError(ref err) => err.description(),
             Error::FormatError(reason) => reason,
+            Error::InvalidState(reason) => reason,
             Error::TooWide => "the sample has more bits than the destination type",
             Error::UnfinishedSample => "the number of samples written is not a multiple of the number of channels",
             Error::Unsupported => "the wave format of the file is not supported",
@@ -391,6 +398,7 @@ impl error::Error for Error {
         match *self {
             Error::IoError(ref err) => Some(err),
             Error::FormatError(_) => None,
+            Error::InvalidState(_) => None,
             Error::TooWide => None,
             Error::UnfinishedSample => None,
             Error::Unsupported => None,
@@ -790,3 +798,98 @@ fn append_works_on_files() {
 
     assert_contents("append.wav", &[11, 13, 17, 19, 23]);
 }
+
+#[test]
+fn write_read_chunks_is_lossless() {
+    let vec = Vec::new();
+    let mut buffer = io::Cursor::new(vec);
+    let write_spec = WavSpec {
+        channels: 2,
+        sample_rate: 44100,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    {
+        let mut writer = WavWriter::new(&mut buffer, write_spec).unwrap();
+        for s in -1024_i16..1024 {
+            writer.write_sample(s).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+    /*
+    {
+        let mut writer = WavWriter::new_with_chunks(&mut buffer, write_spec, &[(*b"houn", b"1234")]).unwrap();
+        for s in -1024_i16..1024 {
+            writer.write_sample(s).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+    */
+    {
+        buffer.set_position(0);
+        //let mut chunk_counter = 0;
+
+        let mut reader = read::ChunksReader::new(&mut buffer).unwrap();
+
+        let fmt = reader.next_chunk().unwrap().unwrap();
+        assert!(fmt.kind == read::ChunkKind::Fmt);
+        let _spec = reader.read_fmt_chunk().unwrap();
+
+        let data = reader.next_chunk().unwrap().unwrap();
+        assert!(data.kind == read::ChunkKind::Data);
+        let mut reader = reader.into_wav_reader().unwrap();
+
+        /*
+        let mut reader = WavReader::new_with_unknown_handler(&mut buffer, Some(&mut |code, data| {
+            assert_eq!(code, *b"houn");
+            assert_eq!(data, b"1234");
+            chunk_counter += 1;
+            Ok(())
+        })).unwrap();
+        */
+        //assert_eq!(chunk_counter, 1);
+
+        assert_eq!(write_spec, reader.spec());
+        assert_eq!(reader.len(), 2048);
+        for (expected, read) in (-1024_i16..1024).zip(reader.samples()) {
+            assert_eq!(expected, read.unwrap());
+        }
+    }
+}
+
+/*
+#[test]
+fn write_read_chunks_odd_size_is_lossless() {
+    let vec = Vec::new();
+    let mut buffer = io::Cursor::new(vec);
+    let write_spec = WavSpec {
+        channels: 2,
+        sample_rate: 44100,
+        bits_per_sample: 16,
+        sample_format: SampleFormat::Int,
+    };
+    {
+        let mut writer = WavWriter::new_with_chunks(&mut buffer, write_spec, &[(*b"houn", b"12345")]).unwrap();
+        for s in -1024_i16..1024 {
+            writer.write_sample(s).unwrap();
+        }
+        writer.finalize().unwrap();
+    }
+    {
+        buffer.set_position(0);
+        let mut chunk_counter = 0;
+        let mut reader = WavReader::new_with_unknown_handler(&mut buffer, Some(&mut |code, data| {
+            assert_eq!(code, *b"houn");
+            assert_eq!(data, b"12345");
+            chunk_counter += 1;
+            Ok(())
+        })).unwrap();
+        assert_eq!(chunk_counter, 1);
+        assert_eq!(write_spec, reader.spec());
+        assert_eq!(reader.len(), 2048);
+        for (expected, read) in (-1024_i16..1024).zip(reader.samples()) {
+            assert_eq!(expected, read.unwrap());
+        }
+    }
+}
+*/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,17 +792,6 @@ fn append_works_on_files() {
 }
 
 #[cfg(test)]
-macro_rules! panic_unless_let {
-    ($pat:pat = $expr:expr) => {
-        if let $pat = $expr {
-            ()
-        } else {
-            panic!("Expected {} to match {}", stringify!($expr), stringify!($pat))
-        }
-    }
-}
-
-#[cfg(test)]
 macro_rules! gard {
     ($pat:pat = $expr:expr => $block:block) => {
         if let $pat = $expr {
@@ -813,6 +802,7 @@ macro_rules! gard {
     }
 }
 
+#[cfg(test)]
 #[test]
 fn read_non_standard_chunks() {
     use std::fs;

--- a/src/read.rs
+++ b/src/read.rs
@@ -794,6 +794,9 @@ impl<R> WavReader<R>
     pub fn new(reader: R) -> Result<WavReader<R>> {
         let mut reader = try!(ChunksReader::new(reader));
         try!(reader.read_until_data());
+        if reader.spec_ex.is_none() {
+            return Err(Error::FormatError("Wave file with no fmt header"))
+        }
         Ok(WavReader {
             reader: reader,
         })
@@ -802,7 +805,7 @@ impl<R> WavReader<R>
     /// Returns information about the WAVE file.
     pub fn spec(&self) -> WavSpec {
         self.reader.spec_ex
-            .expect("WavReader's chunk reader must have find a format")
+            .expect("Using a WavReader wrapping a ChunkReader with no spec")
             .spec
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -202,7 +202,7 @@ impl<'r, R: 'r + io::Read> Drop for EmbeddedReader<'r, R> {
 
 impl<'r, R: io::Read> io::Read for EmbeddedReader<'r, R> {
     fn read(&mut self, buffer: &mut[u8]) -> io::Result<usize> {
-        let max = buffer.len().min(self.remaining as usize);
+        let max = cmp::min(buffer.len(), self.remaining as usize);
         let read = try!(self.reader.read(&mut buffer[0..max]));
         self.remaining -= read as i64;
         Ok(read)
@@ -700,7 +700,7 @@ impl<R: io::Read> io::Read for ChunksReader<R> {
         if data.remaining <= 0 {
             return Ok(0)
         }
-        let max = buffer.len().min(data.remaining as usize);
+        let max = cmp::min(buffer.len(), data.remaining as usize);
         let read = try!(self.reader.read(&mut buffer[0..max]));
         self.data_state.as_mut().unwrap().remaining -= read as i64;
         Ok(read)

--- a/src/write.rs
+++ b/src/write.rs
@@ -545,10 +545,10 @@ impl<W> Drop for WavWriter<W>
 ///
 /// Returns (spec_ex, data_len, data_len_offset).
 fn read_append<W: io::Read + io::Seek>(mut reader: &mut W) -> Result<(WavSpecEx, u32, u32)> {
-    let (spec_ex, data_len) = {
-        try!(read::read_wave_header(&mut reader));
-        try!(read::read_until_data(&mut reader))
-    };
+    try!(read::read_wave_header(&mut reader));
+    let mut chunk_reader = read::ChunksReader::new(reader);
+    let (spec_ex, data_len) = try!(read::read_until_data(&mut chunk_reader));
+    let reader = chunk_reader.into_inner();
 
     // Record the position of the data chunk length, so we can overwrite it
     // later.

--- a/src/write.rs
+++ b/src/write.rs
@@ -555,11 +555,11 @@ fn read_append<W: io::Read + io::Seek>(reader: &mut W) -> Result<(WavSpecEx, u32
     // later.
     let data_len_offset = try!(reader.seek(io::SeekFrom::Current(0))) as u32 - 4;
 
-    let num_samples = data_state.len / spec_ex.bytes_per_sample as i64;
+    let num_samples = data_state.chunk.len / spec_ex.bytes_per_sample as u64;
 
     // There must not be trailing bytes in the data chunk, otherwise the
     // bytes we write will be off.
-    if num_samples * data_state.spec_ex.bytes_per_sample as i64 != data_state.len {
+    if num_samples * data_state.spec_ex.bytes_per_sample as u64 != data_state.chunk.len {
         let msg = "data chunk length is not a multiple of sample size";
         return Err(Error::FormatError(msg));
     }
@@ -581,11 +581,11 @@ fn read_append<W: io::Read + io::Seek>(reader: &mut W) -> Result<(WavSpecEx, u32
     // The number of samples must be a multiple of the number of channels,
     // otherwise the last inter-channel sample would not have data for all
     // channels.
-    if num_samples % spec_ex.spec.channels as i64 != 0 {
+    if num_samples % spec_ex.spec.channels as u64 != 0 {
         return Err(Error::FormatError("invalid data chunk length"));
     }
 
-    Ok((spec_ex, data_state.len as u32, data_len_offset))
+    Ok((spec_ex, data_state.chunk.len as u32, data_len_offset))
 }
 
 impl WavWriter<io::BufWriter<fs::File>> {


### PR DESCRIPTION
Hello there, this is an extension to support writting and reading arbitrary chunks between "fmt " and "data".

Let me know what you think.

(By the way, I think there is a tiny bug in skip_bytes call while looking for the data chunk. As far as I understand it, RIFF chunks must be aligned to even offsets so there might be a padding zero byte... This patch actually fixes it.)