### PR TITLE
Ensure RIFF header is updated on *append()

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -794,7 +794,7 @@ impl WavWriter<io::BufWriter<fs::File>> {
                 spec_ex: Some(spec_ex),
                 writer: buf_writer,
                 sample_writer_buffer: Vec::new(),
-                dirty: false,
+                dirty: true,
                 data_state: Some(ChunkWritingState { len: data_len }),
             }
         };
@@ -824,7 +824,7 @@ impl<W> WavWriter<W> where W: io::Read + io::Write + io::Seek {
                 spec_ex: Some(spec_ex),
                 writer: writer,
                 sample_writer_buffer: Vec::new(),
-                dirty: false,
+                dirty: true,
                 data_state: Some(ChunkWritingState { len: data_len }),
             }
         };


### PR DESCRIPTION
**TL;DR:** Set `dirty: true` if appending.

# Details

On current master, [`pub fn update_headers`](https://github.com/ruuda/hound/blob/bcd553ce377455775513afbb1c752403543bab6e/src/write.rs#L310) only updates the RIFF header  if `self.dirty` is `true`.

`self.dirty` is only being set to `true` by [`pub fn start_chunk`](https://github.com/ruuda/hound/blob/bcd553ce377455775513afbb1c752403543bab6e/src/write.rs#L287) or [`pub fn start_data_chunk`](https://github.com/ruuda/hound/blob/bcd553ce377455775513afbb1c752403543bab6e/src/write.rs#L305).

Since both [`pub fn append`](https://github.com/ruuda/hound/blob/bcd553ce377455775513afbb1c752403543bab6e/src/write.rs#L773) and [`pub fn new_append`](https://github.com/ruuda/hound/blob/bcd553ce377455775513afbb1c752403543bab6e/src/write.rs#L819) create their `ChunksWriter` with `dirty: false`, but both Writers are assumed to already have a data chunk (otherwise writing to them panics with `Invalid state, should be in DATA`), every file  *appended to* by hound will have an invalid RIFF header after flushing.

This PR therefore sets `dirty: true` for `ChunksWriter` in both `*append` methods.