### PR TITLE
Propose changes to address undefined behavior 

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -29,8 +29,8 @@ pub trait ReadExt: io::Read {
     //  TODO: There is an RFC proposing a method like this for the standard library.
     fn read_into(&mut self, buf: &mut [u8]) -> io::Result<()>;
 
-    /// Reads `n` bytes and returns them in a vector.
-    fn read_bytes(&mut self, n: usize) -> io::Result<Vec<u8>>;
+    /// Reads 4 bytes and returns them in an array.
+    fn read_4_bytes(&mut self) -> io::Result<[u8; 4]>;
 
     /// Skip over `n` bytes.
     fn skip_bytes(&mut self, n: usize) -> io::Result<()>;
@@ -110,13 +110,8 @@ impl<R> ReadExt for R
     }
 
     #[inline(always)]
-    fn read_bytes(&mut self, n: usize) -> io::Result<Vec<u8>> {
-        // We allocate a runtime fixed size buffer, and we are going to read
-        // into it, so zeroing or filling the buffer is a waste. This method
-        // is safe, because the contents of the buffer are only exposed when
-        // they have been overwritten completely by the read.
-        let mut buf = Vec::with_capacity(n);
-        unsafe { buf.set_len(n); }
+    fn read_4_bytes(&mut self) -> io::Result<[u8; 4]> {
+        let mut buf = [0_u8; 4];
         try!(self.read_into(&mut buf[..]));
         Ok(buf)
     }
@@ -192,8 +187,10 @@ impl<R> ReadExt for R
     }
 
     #[inline(always)]
-    fn read_le_f32(&mut self) -> io::Result<f32> {
-        self.read_le_u32().map(|u| unsafe { mem::transmute(u) })
+    fn read_le_f32(&mut self) -> io::Result<f32> {    
+        let mut buf = [0u8; 4];
+        try!(self.read_into(&mut buf));
+        Ok(f32::from_le_bytes(buf))
     }
 }
 
@@ -767,14 +764,14 @@ pub fn read_wave_header<R: io::Read>(reader: &mut R) -> Result<u64> {
     // into it is more cumbersome, but also avoids a heap allocation. Is
     // the compiler smart enough to avoid the heap allocation anyway? I
     // would not expect it to be.
-    if b"RIFF" != &try!(reader.read_bytes(4))[..] {
+    if b"RIFF" != &try!(reader.read_4_bytes())[..] {
         return Err(Error::FormatError("no RIFF tag found"));
     }
 
     let file_len = try!(reader.read_le_u32());
 
     // Next four bytes indicate the file type, which should be WAVE.
-    if b"WAVE" != &try!(reader.read_bytes(4))[..] {
+    if b"WAVE" != &try!(reader.read_4_bytes())[..] {
         return Err(Error::FormatError("no WAVE tag found"));
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -14,6 +14,7 @@ use std::fs;
 use std::io;
 use std::mem;
 use std::io::{Seek, Write};
+use std::mem::MaybeUninit;
 use std::path;
 use super::{Error, Result, Sample, SampleFormat, WavSpec};
 use ::read;
@@ -115,7 +116,7 @@ impl<W> WriteExt for W
 
     #[inline(always)]
     fn write_le_f32(&mut self, x: f32) -> io::Result<()> {
-        let u = unsafe { mem::transmute(x) };
+        let u = unsafe { mem::transmute::<f32, u32>(x) };
         self.write_le_u32(u)
     }
 }
@@ -229,7 +230,7 @@ pub struct ChunksWriter<W: io::Write + io::Seek> {
     /// state of the data chunk, if currently writing it
     pub data_state: Option<ChunkWritingState>,
     dirty: bool,
-    sample_writer_buffer: Vec<u8>,
+    sample_writer_buffer: Vec<MaybeUninit<u8>>,
 }
 
 impl<W: io::Write + io::Seek> ChunksWriter<W> {
@@ -559,7 +560,7 @@ impl<W: io::Write + io::Seek> ChunksWriter<W> {
             // We need a bigger buffer. There is no point in growing the old
             // one, as we are going to overwrite the samples anyway, so just
             // allocate a new one.
-            let mut new_buffer = Vec::with_capacity(num_bytes);
+            let mut new_buffer = Vec::<MaybeUninit<u8>>::with_capacity(num_bytes);
 
             // The potentially garbage memory here will not be exposed: the
             // buffer is only exposed when flushing, but `flush()` asserts that
@@ -884,7 +885,7 @@ pub struct SampleWriter16<'parent, W> where W: io::Write + io::Seek + 'parent {
     writer: &'parent mut W,
 
     /// The internal buffer that samples are written to before they are flushed.
-    buffer: &'parent mut [u8],
+    buffer: &'parent mut [MaybeUninit<u8>],
 
     /// Reference to the `data_bytes_written` field of the writer.
     data_bytes_written: &'parent mut u32,
@@ -915,27 +916,18 @@ impl<'parent, W: io::Write + io::Seek> SampleWriter16<'parent, W> {
         let s = sample.as_i16() as u16;
 
         // Write the sample in little endian to the buffer.
-        self.buffer[self.index as usize] = s as u8;
-        self.buffer[self.index as usize + 1] = (s >> 8) as u8;
+        self.buffer[self.index as usize].write(s as u8);
+        self.buffer[self.index as usize + 1].write((s >> 8) as u8);
 
         self.index += 2;
     }
 
-    #[cfg(target_arch = "x86_64")]
     unsafe fn write_u16_le_unchecked(&mut self, value: u16) {
-        // x86_64 is little endian, so we do not need to shuffle bytes around;
-        // we can just store the 16-bit integer in the buffer directly.
-        let ptr = self.buffer.get_unchecked_mut(self.index as usize) as *mut u8 as *mut u16;
-        *ptr = value;
-    }
+        // On little endian machines the compiler produces assembly code
+        // that merges the following two lines into a single instruction. 
 
-    #[cfg(not(target_arch = "x86_64"))]
-    unsafe fn write_u16_le_unchecked(&mut self, value: u16) {
-        // Write a sample in little-endian to the buffer, independent of the
-        // endianness of the architecture we are running on.
-        let idx = self.index as usize;
-        *self.buffer.get_unchecked_mut(idx) = value as u8;
-        *self.buffer.get_unchecked_mut(idx + 1) = (value >> 8) as u8;
+        self.buffer.get_unchecked_mut(self.index as usize).write(value as u8);
+        self.buffer.get_unchecked_mut(self.index as usize + 1).write((value >> 8) as u8);
     }
 
     /// Like `write_sample()`, but does not perform a bounds check when writing
@@ -960,7 +952,15 @@ impl<'parent, W: io::Write + io::Seek> SampleWriter16<'parent, W> {
             panic!("Insufficient samples written to the sample writer.");
         }
 
-        try!(self.writer.write_all(&self.buffer));
+        // SAFETY: casting `self.buffer` to a `*const [MaybeUninit<u8>]` is safe since the caller guarantees that
+        // `self.buffer` is initialized, and `MaybeUninit<u8>` is guaranteed to have the same layout as `u8`.
+        // The pointer obtained is valid since it refers to memory owned by `self.buffer` which is a
+        // reference and thus guaranteed to be valid for reads.
+        // This is copied from the nightly implementation for slice_assume_init_ref.
+        let slice = unsafe { &*(self.buffer as *const [MaybeUninit<u8>] as *const [u8]) };
+
+        try!(self.writer.write_all(slice));
+
         *self.data_bytes_written += self.buffer.len() as u32;
         Ok(())
     }


### PR DESCRIPTION
Hello, thank you for making this crate. Here are some proposed changes to unsafe code that avoid undefined behavior. These changes either maintain the optimizations that the original versions contained or incur minimal overhead in the existing context. 

For `src/read.rs::read_bytes`, creating a reference to uninitialized memory is considered undefined behavior [(tracked issue)](https://github.com/rust-lang/rust-clippy/issues/4483). Since the function is called with n = 4 bytes, the initialization overhead should be minimal.

For calls to `mem::transmute`, we can add explicit return types to avoid possible unpredicted types from inference. 

For the buffer fields in `ChunksWriter` and `SampleWriter16`, we can use `MaybeUninit<u8>` to be explicit about when the values are initialized to avoid undefined behavior of creating references to uninitialized memory. 

In  `write_sample<S: Sample>`the calls to `write` on `MaybeUninit<u8>`'s behave the same as writing the `u8` values as before.

For `write_u16_le_unchecked`, we can use `MaybeUninit::write()` like we did for `write_sample` but instead of referencing a bounds checked element at an index, we can get an unchecked reference as before. 

Assmebly code for `write_u16_unchecked` can be found [here](https://rust.godbolt.org/z/jb98q7hjr).

Thanks again for maintaining this awesome crate, I hope you find these proposed changes useful for future development and use. 