### PR TITLE
Clamp channels in WAVEFORMATEXTENSIBLE mode to avoid overflow

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -121,8 +121,14 @@ impl<W> WriteExt for W
 }
 
 /// Generates a bitmask with `channels` ones in the least significant bits.
+///
+/// According to the [spec](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-waveformatextensible#remarks),
+/// if `channels` is greater than the number of bits in the channel mask, 18 non-reserved bits,
+/// extra channels are not assigned to any physical speaker location.  In this scenario, this
+/// function will return a filled channel mask.
 fn channel_mask(channels: u16) -> u32 {
-    (0..channels).map(|c| 1 << c).fold(0, |a, c| a | c)
+    // clamp to 0-18 to stay within reserved bits
+    (0..channels.clamp(0, 18) as u32).map(|c| 1 << c).fold(0, |a, c| a | c)
 }
 
 #[test]
@@ -131,7 +137,14 @@ fn verify_channel_mask() {
     assert_eq!(channel_mask(1), 1);
     assert_eq!(channel_mask(2), 3);
     assert_eq!(channel_mask(3), 7);
-    assert_eq!(channel_mask(4), 15);
+    assert_eq!(channel_mask(4), 0xF);
+    assert_eq!(channel_mask(8), 0xFF);
+    assert_eq!(channel_mask(16), 0xFFFF);
+    // expect channels >= 18 to yield the same mask
+    assert_eq!(channel_mask(18), 0x3FFFF);
+    assert_eq!(channel_mask(32), 0x3FFFF);
+    assert_eq!(channel_mask(64), 0x3FFFF);
+    assert_eq!(channel_mask(129), 0x3FFFF);
 }
 
 enum FmtKind {


### PR DESCRIPTION
Thank you to everyone involved in creating this awesome library!  

I noticed that when creating a spec with `channels` > 32, an overflow occurs due to bit-shifting past the limits of the `u32` type when creating the channel mask for `WAVEFORMATEXTENSIBLE` mode.  Here is a minimal example to reproduce the behavior:
```rust
use hound;

fn main() {
    let spec = hound::WavSpec {
        channels: 33,
        sample_rate: 44100,
        bits_per_sample: 16,
        sample_format: hound::SampleFormat::Int,
    };
    hound::WavWriter::create("sine.wav", spec).unwrap();
}
```

After researching the [spec](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ksmedia/ns-ksmedia-waveformatextensible#remarks), it mentions that: 
> If nChannels exceeds the number of bits set in dwChannelMask, the channels that have no corresponding mask bits are not assigned to any physical speaker position. In any speaker configuration other than KSAUDIO_SPEAKER_DIRECTOUT, an audio sink like KMixer (see [KMixer System Driver](https://docs.microsoft.com/en-us/windows-hardware/drivers/audio/kernel-mode-wdm-audio-components)) simply ignores these excess channels and mixes only the channels that have corresponding mask bits.

It also mentions that:
> Channel locations beyond the predefined ones are considered reserved.

Since there are 18 predefined channel locations, I clamped the `channels` param to 0-18 to both ignore channels that don't have a corresponding mask bit, and to avoid writing to reserved bits.

---
I opened an issue for this, #60, but it is also worth noting that this method of bit shifting does not generate the same predefined masks that are detailed by the spec.  I'm not sure if this was intentional, but I left this behavior in up to 18 channels to preserve this choice.