### PR TITLE
Allow mutable access to the inner stream

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -868,7 +868,7 @@ impl<R> WavReader<R>
 
     /// Grants mutable access to the underlying reader.
     pub fn inner(&mut self) -> &mut R {
-        self.reader.inner();
+        self.reader.inner()
     }
 
     /// Seek to the given time within the file.


### PR DESCRIPTION
Why?
Because you can then use something like a 
std::io::Cursor<Vec<i16>> and write to it on the fly.

The reader can be queried for the remaining samples, and thus we can make sure that we don't read past the end of the stream.

