### PR TITLE
Fix set correct mask for 1 channel to be CENTER_SPEAKER

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "alsa-sys"
-version = "0.1.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9013f855a808ab924a4c08b5c1ec9bd6b04fdb2295b4d570fb723e0ed2802a4f"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
 dependencies = [
  "libc",
  "pkg-config",
@@ -61,15 +61,15 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.0"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9e1e434b35b61b6422b19998d5c219f6b4a90aae841583444b44077adb953b"
+checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 
 [[package]]
 name = "libc"
-version = "0.2.23"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "ole32-sys"
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.9"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "winapi"

--- a/src/write.rs
+++ b/src/write.rs
@@ -128,14 +128,20 @@ impl<W> WriteExt for W
 /// extra channels are not assigned to any physical speaker location.  In this scenario, this
 /// function will return a filled channel mask.
 fn channel_mask(channels: u16) -> u32 {
+    // If the channel count is 1, then the mask will be 0x4, for use with mono audio with the FRONT_CENTER speaker
+    // see https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.10240.0/shared/ksmedia.h#L1695C42-L1695C62
+    if channels == 1 {
+        return 0x4;
+    }
     // clamp to 0-18 to stay within reserved bits
     (0..channels.clamp(0, 18) as u32).map(|c| 1 << c).fold(0, |a, c| a | c)
+
 }
 
 #[test]
 fn verify_channel_mask() {
     assert_eq!(channel_mask(0), 0);
-    assert_eq!(channel_mask(1), 1);
+    assert_eq!(channel_mask(1), 4);
     assert_eq!(channel_mask(2), 3);
     assert_eq!(channel_mask(3), 7);
     assert_eq!(channel_mask(4), 0xF);


### PR DESCRIPTION
ISSUE: https://github.com/ruuda/hound/issues/87

By the default when 1 channel is requested the speaker mask should be MONO  with CENTER_SPEAKER mapping according to https://github.com/tpn/winsdk-10/blob/9b69fd26ac0c7d0b83d378dba01080e93349c2ed/Include/10.0.10240.0/shared/ksmedia.h#L1695C42-L1695C62