### PR TITLE
add WavSpec chaining methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,6 +543,30 @@ impl WavSpec {
 
         v
     }
+     
+    /// Sets the number of channels.
+    pub fn channels(mut self, channels: u16) -> Self {
+        self.channels = channels;
+        self
+    }
+
+    /// Sets the number of samples per second.
+    pub fn sample_rate(mut self, sample_rate: u32) -> Self {
+        self.sample_rate = sample_rate;
+        self
+    }
+
+    /// Sets the number of bits per sample.
+    pub fn bits_per_sample(mut self, bits_per_sample: u16) -> Self {
+        self.bits_per_sample = bits_per_sample;
+        self
+    }
+
+    /// Sets whether the wav's samples are float or integer values.
+    pub fn sample_format(mut self, sample_format: SampleFormat) -> Self {
+        self.sample_format = sample_format;
+        self
+    }
 }
 
 #[test]

--- a/src/read.rs
+++ b/src/read.rs
@@ -719,6 +719,20 @@ pub struct WavSpecEx {
     pub bytes_per_sample: u16,
 }
 
+impl WavSpecEx {
+    /// Sets the normal information about the audio data.
+    pub fn spec(mut self, spec: WavSpec) -> Self {
+        self.spec = spec;
+        self
+    }
+
+    /// Sets the number of bytes used to store a sample.
+    pub fn bytes_per_sample(mut self, bytes_per_sample: u16) -> Self {
+        self.bytes_per_sample = bytes_per_sample;
+        self
+    }
+}
+
 /// A reader that reads the WAVE format from the underlying reader.
 ///
 /// A `WavReader` is a streaming reader. It reads data from the underlying


### PR DESCRIPTION
Adds some methods that makes code easier to write

changing a sample rate before e.g.:
``` rust
let r = WavReader::open("signal.wav").unwrap();
let mut w = WavWriter::create("output.wav", {
    let mut spec = r.spec();
    spec.sample_rate = 8_000;
    spec
})
.unwrap();
```

After
```rust
let r = WavReader::open("signal.wav").unwrap();
let mut w = WavWriter::create("output.wav", r.spec().sample_rate(8_000)).unwrap();
```