### PR TITLE
remove rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,0 @@
-[toolchain]
-# Note, this is the Minimum Supported Rust Version. We build with this by
-# default to ensure we don't accidentally break it, but of course you should be
-# able to build with more recent versions.
-channel = "1.40.0"


### PR DESCRIPTION
Rather than acting as a minimum supported version, this seems to be enforced strictly; with the rust-toolchain file, I would get this error on Apple silicon:

```
   Compiling bevy_gilrs v0.16.1
info: syncing channel updates for '1.40.0-aarch64-apple-darwin'
info: latest update on 2019-12-19, rust version 1.40.0 (73528e339 2019-12-16)
error: target 'aarch64-apple-darwin' not found in channel.  Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets
error: could not compile `hound` (lib)

Caused by:
  process didn't exit successfully: `rustc --crate-name hound --edition=2015 /Users/bbarker/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hound-3.5.1/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --diagnostic-width=114 --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked -C debug-assertions=on --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values())' -C metadata=1dd0d64c4350faa4 -C extra-filename=-251b1d315444790b --out-dir /Users/bbarker/workspace/flame_and_fortune/target/debug/deps -L dependency=/Users/bbarker/workspace/flame_and_fortune/target/debug/deps --cap-lints allow` (exit status: 1)
```