### PR TITLE
silently discard trailing partial sample byte

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -599,15 +599,11 @@ impl<R> WavReader<R>
 
         let num_samples = data_len / spec_ex.bytes_per_sample as u32;
 
-        // It could be that num_samples * bytes_per_sample < data_len.
-        // If data_len is not a multiple of bytes_per_sample, there is some
-        // trailing data. Either somebody is playing some steganography game,
-        // but more likely something is very wrong, and we should refuse to
-        // decode the file, as it is invalid.
-        if num_samples * spec_ex.bytes_per_sample as u32 != data_len {
-            let msg = "data chunk length is not a multiple of sample size";
-            return Err(Error::FormatError(msg));
-        }
+        // If data_len is not a multiple of bytes_per_sample, the trailing
+        // partial sample byte(s) are silently discarded. The integer division
+        // above already truncates to the last complete sample frame.
+        // This tolerates WAV files where the last byte of a multi-byte sample
+        // was lost (e.g., truncated file transfers).
 
         // The number of samples must be a multiple of the number of channels,
         // otherwise the last inter-channel sample would not have data for all


### PR DESCRIPTION
## Problem

close https://github.com/ruuda/hound/issues/63, close https://github.com/ruuda/hound/issues/81

`WavReader::new()` currently rejects WAV files where `data_len % bytes_per_sample != 0`, returning an `Error::FormatError` ("data chunk length is not a multiple of sample size").

However, real-world audio files often have a missing final byte from truncated transfers, and mainstream players (VLC, ffmpeg, Symphonia) handle them gracefully by ignoring the trailing byte(s).

## Why the change is safe

- `num_samples` is computed via integer division, which naturally discards the partial trailing sample.
- `WavReader` only uses `num_samples` for subsequent reads — the truncated `data_len` is never referenced again.

## Verification

Tested against 7 real-world truncated WAV files that previously failed:
- 6 files from a legacy game asset collection (16-bit mono, 22050 Hz)
- 1 file from hound issue #81 (16-bit mono, 24000 Hz)

All 7 files now decode successfully with the patch, producing the expected sample counts (last partial sample silently dropped). 88 non-truncated control files continue to decode identically.
